### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/Abune.Server.Test/Abune.Server.Test.csproj
+++ b/src/Abune.Server.Test/Abune.Server.Test.csproj
@@ -16,16 +16,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.4.10" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.4.17" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.14.6" />
-    <PackageReference Include="nunit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Hi@motmot80, I found an issue in the Abune.Server.Test.csproj:

Packages Akka.TestKit.Xunit2 v1.4.10, BenchmarkDotNet v0.12.1, Microsoft.CodeAnalysis.FxCopAnalyzers v2.9.6, Moq v4.14.6, nunit v3.10.1, NUnit3TestAdapter v3.10.0 and Microsoft.NET.Test.Sdk v15.8.0 transitively introduce 97 dependencies into Abune.Server’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/Abune-Server.html)), while Akka.TestKit.Xunit2 v1.4.17, BenchmarkDotNet v0.13.0, Microsoft.CodeAnalysis.FxCopAnalyzers v2.9.8, Moq v4.16.0, nunit v3.13.1, NUnit3TestAdapter v4.0.0 and Microsoft.NET.Test.Sdk v15.9.1 can only introduce 63 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/Abune-Server_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose